### PR TITLE
NoContent() should not accept content

### DIFF
--- a/respond/errors.go
+++ b/respond/errors.go
@@ -50,8 +50,8 @@ func Accepted(msg string) internal.HttpResponse {
 }
 
 // NoContent creates a HTTP 204 No Content response.
-func NoContent(msg string) internal.HttpResponse {
-	return httpError{204, msg}
+func NoContent() internal.HttpResponse {
+	return httpError{204, ""}
 }
 
 // ResetContent creates a HTTP 205 Reset Content response.


### PR DESCRIPTION
The RFC forbids content when using HTTP status code 204, so we should not allow for any content